### PR TITLE
Add pagination to venues

### DIFF
--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -3,7 +3,7 @@ class VenuesController < ApplicationController
   before_action :set_venue, only: [:show]
 
   def index
-    @venues = Venue.all
+    @venues = Venue.paginate(:page => params[:page], :per_page => 30)
   end
 
   def show

--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -4,3 +4,5 @@
     <%= render partial: 'venues/venue_details', locals: {venue: venue} %>
   </div>
 <% end %>
+
+<%= will_paginate @venues %>

--- a/spec/features/venues/user_can_view_all_venues_spec.rb
+++ b/spec/features/venues/user_can_view_all_venues_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Guest can view a list of all venues' do
-  let!(:venues) { create_list(:venue, 3) }
+  let!(:venues) { create_list(:venue, 35) }
+
   context 'without being logged in' do
     it 'guest can view a list of venues' do
       visit root_path
@@ -13,13 +14,40 @@ RSpec.feature 'Guest can view a list of all venues' do
       expect(current_path).to eq venues_path
 
       html_venues = page.all(".venue")
-      expect(html_venues.count).to eq 3
+      expect(html_venues.count).to eq 30
 
       expect(html_venues[0]).to have_link(venues.first.name, href: venue_path(venues.first))
       expect(html_venues[0]).to have_content(venues.first.street_address)
       expect(html_venues[0]).to have_content(venues.first.city)
       expect(html_venues[0]).to have_content(venues.first.state)
       expect(html_venues[0]).to have_content(venues.first.zip)
+
+      expect(page).to have_css '.next_page'
+    end
+
+    it 'guest can view second page of venues' do
+      visit root_path
+
+      within '.right' do
+        click_on 'Venues'
+      end
+
+      within '.pagination .next_page' do
+        click_link
+      end
+
+      expect(current_path).to eq venues_path
+
+      html_venues = page.all('.venue')
+      expect(html_venues.count).to eq 5
+
+      expect(html_venues[4]).to have_link(venues.last.name, href: venue_path(venues.last))
+      expect(html_venues[4]).to have_content(venues.last.street_address)
+      expect(html_venues[4]).to have_content(venues.last.city)
+      expect(html_venues[4]).to have_content(venues.last.state)
+      expect(html_venues[4]).to have_content(venues.last.zip)
+
+      expect(page).to have_css '.previous_page'
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
update venues spec to test for pagination and add pagination to venues index

#### Where should the reviewer start?
`venues_controller` and `views/venues/index.html.erb`

#### How should this be manually tested?
- Start `rails s`
- Visit `http://localhost:3000`
- Click on "Venues"
- View the venues and use the pagination

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions:
  - Do Migrations Need to be ran? No
  - Do Environment Variables need to be set? No
  - Any other deploy steps? No
