### PR TITLE
Venue Show With Map

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,10 @@
 @import "materialize";
 @import "materialize/extras/nouislider";
 @import "https://fonts.googleapis.com/icon?family=Material+Icons";
+
+#map {
+  width: 50%;
+  height: 50%;
+  min-height: 300px;
+  min-width: 300px;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,5 +15,6 @@
       <%= render 'layouts/flash' %>
       <%= yield %>
     </div>
+    <%= yield :foot %>
   </body>
 </html>

--- a/app/views/manager/venues/index.html.erb
+++ b/app/views/manager/venues/index.html.erb
@@ -1,6 +1,6 @@
 <% @venues.each do |venue| %>
   <div class="venue">
-    <p><%= link_to venue.name, venue_path(venue) %></p>
+    <p><%= link_to venue.name, manager_venue_path(venue) %></p>
     <%= render partial: 'venues/venue_details', locals: {venue: venue} %>
   </div>
 <% end %>

--- a/app/views/manager/venues/show.html.erb
+++ b/app/views/manager/venues/show.html.erb
@@ -1,3 +1,4 @@
 <h2><%= @venue.name %></h2>
 <%= link_to "Edit", edit_manager_venue_path(@venue) %>
 <%= render partial: 'venues/venue_details', locals: {venue: @venue} %>
+<%= render partial: 'venues/venue_map' %>

--- a/app/views/venues/_venue_map.html.erb
+++ b/app/views/venues/_venue_map.html.erb
@@ -1,0 +1,24 @@
+<div id="map"></div>
+
+<% content_for :foot do %>
+  <script>
+    function initMap() {
+      var myLatLng = {lat: <%= @venue.latitude %>, lng: <%= @venue.longitude %>};
+
+        // Create a map object and specify the DOM element for display.
+        var map = new google.maps.Map(document.getElementById('map'), {
+          center: myLatLng,
+          scrollwheel: false,
+          zoom: 8
+        });
+
+        // Create a marker and set its position.
+        var marker = new google.maps.Marker({
+          map: map,
+          position: myLatLng,
+          title: '<%= @venue.name %>'
+        });
+    }
+  </script>
+  <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAP_KEY']}&callback=initMap", async: true, defer: true %>
+<% end %>

--- a/app/views/venues/show.html.erb
+++ b/app/views/venues/show.html.erb
@@ -1,2 +1,3 @@
 <h2><%= @venue.name %></h2>
 <%= render partial: 'venues/venue_details', locals: {venue: @venue} %>
+<%= render partial: 'venues/venue_map' %>

--- a/spec/features/users/managers/managers_can_see_a_list_of_all_their_venues_spec.rb
+++ b/spec/features/users/managers/managers_can_see_a_list_of_all_their_venues_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Managers can see a list of their venues" do
 
       expect(html_venues.count).to eq 3
 
-      expect(html_venues[0]).to have_link(venues.first.name, href: venue_path(venues.first))
+      expect(html_venues[0]).to have_link(venues.first.name, href: manager_venue_path(venues.first))
       expect(html_venues[0]).to have_content(venues.first.street_address)
       expect(html_venues[0]).to have_content(venues.first.city)
       expect(html_venues[0]).to have_content(venues.first.state)

--- a/spec/features/venues/user_can_view_one_venue_spec.rb
+++ b/spec/features/venues/user_can_view_one_venue_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Guest can view a single venues' do
       expect(page).to have_content(venues.first.city)
       expect(page).to have_content(venues.first.state)
       expect(page).to have_content(venues.first.zip)
+      expect(page).to have_css("#map")
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
add venue map to venue show and manager venue show pages. 

Includes changing update manager index to link to manager show page

[Finishes #148968177]

#### Where should the reviewer start?
`app/views/venues/show.html.erb`

#### How should this be manually tested?
Spin up your server and visit a venue page.  You should see a map with a marker on it.

#### Any background context you want to provide?
#### What are the relevant tickets?
[#148968177](https://www.pivotaltracker.com/story/show/148968177)  

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1408372/28252097-cb0d6a3e-6a49-11e7-99b6-2d226cd15108.png)

#### Questions:
  - Do Migrations Need to be ran? no
  - Do Environment Variables need to be set? **Yes Google Maps API**
  - Any other deploy steps? No
